### PR TITLE
moved alias_method

### DIFF
--- a/lib/elastic_results.rb
+++ b/lib/elastic_results.rb
@@ -108,6 +108,7 @@ module ElasticResults
   ElasticResults.suite_name ||= (ENV['SUITE_NAME'] || File.basename(Dir.pwd))
   ElasticResults.suite_type ||= (ENV['SUITE_TYPE'] || 'integration')
   ElasticResults.es_url     ||= (ENV['ES_HOST']    || 'http://localhost')
+  ElasticResults.es_path     ||= (ENV['ES_PATH']    || '')
   ElasticResults.kibana_url ||= (ENV['KIBANA_URL'] || 'http://localhost:5601')
   ElasticResults.es_log     ||= !ENV['DEBUG'].nil?
   ElasticResults.build_id   ||= DateTime.now.strftime('%Y%m%d%H%M%S%L')
@@ -123,8 +124,6 @@ module ElasticResults
   def self.http_client
     uri = URI.parse(ElasticResults.es_url)
     http = Net::HTTP.new(uri.host, uri.port)
-    
-    ElasticResults.es_path ||= uri.path unless uri.path == ""
     
     if ElasticResults.es_url =~ /https/
       http.use_ssl = true

--- a/lib/elastic_results/cucumber.rb
+++ b/lib/elastic_results/cucumber.rb
@@ -7,15 +7,15 @@ module ElasticResults
     class Formatter < ::Cucumber::Formatter::Json
       include Reportable
 
-      def after_test_case(test_case, result)
-        old_after_test_case test_case, result
+      def after_feature_element(test_case, result)
+        old_after_feature_element test_case, result
 
         feature_hash = @feature_hashes.last
         feature_hash[:elements].each do |scenario_hash|
           record_scenario feature_hash, scenario_hash
         end
       end
-      alias_method :old_after_test_case, :after_test_case
+      alias_method :old_after_feature_element, :after_feature_element
 
       def done
         ElasticResults.write_urls

--- a/lib/elastic_results/cucumber.rb
+++ b/lib/elastic_results/cucumber.rb
@@ -7,7 +7,6 @@ module ElasticResults
     class Formatter < ::Cucumber::Formatter::Json
       include Reportable
 
-      alias_method :old_after_test_case, :after_test_case
       def after_test_case(test_case, result)
         old_after_test_case test_case, result
 
@@ -16,6 +15,7 @@ module ElasticResults
           record_scenario feature_hash, scenario_hash
         end
       end
+      alias_method :old_after_test_case, :after_test_case
 
       def done
         ElasticResults.write_urls


### PR DESCRIPTION
it is neccessary for ruby to find the method definition in the alias call

resolves #8